### PR TITLE
Add a apath.txt file for manual installation of aespm

### DIFF
--- a/aespm/__init__.py
+++ b/aespm/__init__.py
@@ -4,11 +4,6 @@ warnings.filterwarnings("ignore", category=SyntaxWarning)
 
 __all__ = ['experiment']
 
-from aespm.experiment import *
-
-from aespm import tools
-from aespm import utils
-
 # If there is no buffer files, create them in Documents/buffers
 import os 
 import shutil
@@ -24,9 +19,9 @@ if platform.system() == 'Windows':
     # Load the path from file if there is a path.txt in the buffer folder
     path_txt = os.path.join(buffer_path, 'path.txt')
     
-    command_buffer = os.path.join(_buffer_path, 'ToIgor.arcmd')
-    read_out_buffer = os.path.join(_buffer_path, 'readout.txt')
-    bash_buffer = os.path.join(_buffer_path, 'SendToIgor.bat')
+    command_buffer = os.path.join(buffer_path, 'ToIgor.arcmd')
+    read_out_buffer = os.path.join(buffer_path, 'readout.txt')
+    bash_buffer = os.path.join(buffer_path, 'SendToIgor.bat')
     
     try:
         # Create the buffer folder
@@ -45,7 +40,7 @@ if platform.system() == 'Windows':
             
             # Write the exe_path into the bash buffer
             with open(bash_buffer, 'w') as fopen:
-                fopen.write('"{}" "{}"'.format(exe_path, bash_buffer))
+                fopen.write('"{}" "{}"'.format(exe_path, command_buffer))
         else:
             # Fist-time installation: no path_txt file available
             # Detect the AR version and installation path automatically
@@ -70,10 +65,15 @@ if platform.system() == 'Windows':
                 fopen.write(exe_path)
                 
             with open(bash_buffer, 'w') as fopen: 
-                fopen.write('"{}" "{}"'.format(exe_path, bash_buffer))
+                fopen.write('"{}" "{}"'.format(exe_path, command_buffer))
 
             # Copy the user functions into the default include folder of AR
             # shutil.copy(os.path.join(aespm.__path__, 'user functions', 'UserFunctions.ipf'), os.path.join(doc_path, 'AsylumResearch', 'UserIncludes'))
 
     except PermissionError:
         print('No writing permission to ~/Documents. Please create buffer folder and files manually.')
+        
+from aespm.experiment import *
+
+from aespm import tools
+from aespm import utils

--- a/aespm/__init__.py
+++ b/aespm/__init__.py
@@ -75,5 +75,5 @@ if platform.system() == 'Windows':
             # Copy the user functions into the default include folder of AR
             # shutil.copy(os.path.join(aespm.__path__, 'user functions', 'UserFunctions.ipf'), os.path.join(doc_path, 'AsylumResearch', 'UserIncludes'))
 
-	except PermissionError:
-		print('No writing permission to ~/Documents. Please create buffer folder and files manually.')
+    except PermissionError:
+        print('No writing permission to ~/Documents. Please create buffer folder and files manually.')

--- a/aespm/__init__.py
+++ b/aespm/__init__.py
@@ -16,41 +16,64 @@ import platform
 
 doc_path = os.path.expanduser('~')
 buffer_path = os.path.join(doc_path, 'Documents', 'buffer')
-
+    
 # Initialize the buffer files only on Windows operating system
 
 if platform.system() == 'Windows':
-	try:
-		# Create the buffer folder
-		if not os.path.exists(buffer_path):
-			os.makedirs(buffer_path)
 
-		# Create the commands buffer file
-		if not os.path.exists(os.path.join(buffer_path, 'ToIgor.arcmd')):
-			with open(os.path.join(buffer_path, 'ToIgor.arcmd'), 'w') as fopen:
-				fopen.write(' ')
-		# Create bash file to execute commands in hte buffer file
-		if not os.path.exists(os.path.join(buffer_path, 'SendToIgor.bat')):
-			with open(os.path.join(buffer_path, 'SendToIgor.bat'), 'w') as fopen:
-				if os.path.exists("C:\\AsylumResearch\\v19"):
-					fopen.write('"C:\\AsylumResearch\\v19\\RealTime\\Igor Pro Folder\\Igor.exe" "{}"'.format(os.path.join(buffer_path, 'ToIgor.arcmd')))
-				elif os.path.exists("C:\\AsylumResearch\\v18"):
-					fopen.write('"C:\\AsylumResearch\\v18\\RealTime\\Igor Pro Folder\\Igor.exe" "{}"'.format(os.path.join(buffer_path, 'ToIgor.arcmd')))
-				elif os.path.exists("C:\\AsylumResearch\\v17"):
-					fopen.write('"C:\\AsylumResearch\\v17\\RealTime\\Igor Pro Folder\\Igor.exe" "{}"'.format(os.path.join(buffer_path, 'ToIgor.arcmd')))
-				elif os.path.exists("C:\\AsylumResearch\\v16"):
-					fopen.write('"C:\\AsylumResearch\\v16\\RealTime\\Igor Pro Folder\\Igor.exe" "{}"'.format(os.path.join(buffer_path, 'ToIgor.arcmd')))
-				elif os.path.exists("C:\\AsylumResearch\\v15"):
-					fopen.write('"C:\\AsylumResearch\\v15\\RealTime\\Igor Pro Folder\\Igor.exe" "{}"'.format(os.path.join(buffer_path, 'ToIgor.arcmd')))
-				elif os.path.exists("C:\\AsylumResearch\\v14"):
-					fopen.write('"C:\\AsylumResearch\\v14\\RealTime\\Igor Pro Folder\\Igor.exe" "{}"'.format(os.path.join(buffer_path, 'ToIgor.arcmd')))
-				elif os.path.exists("C:\\AsylumResearch\\v13"):
-					fopen.write('"C:\\AsylumResearch\\v13\\RealTime\\Igor Pro Folder\\Igor.exe" "{}"'.format(os.path.join(buffer_path, 'ToIgor.arcmd')))
-				else:
-					print("No supported AR versions!")
+    # Load the path from file if there is a path.txt in the buffer folder
+    path_txt = os.path.join(buffer_path, 'path.txt')
+    
+    command_buffer = os.path.join(_buffer_path, 'ToIgor.arcmd')
+    read_out_buffer = os.path.join(_buffer_path, 'readout.txt')
+    bash_buffer = os.path.join(_buffer_path, 'SendToIgor.bat')
+    
+    try:
+        # Create the buffer folder
+        if not os.path.exists(buffer_path):
+            os.makedirs(buffer_path)
 
-		# Copy the user functions into the default include folder of AR
-		# shutil.copy(os.path.join(aespm.__path__, 'user functions', 'UserFunctions.ipf'), os.path.join(doc_path, 'AsylumResearch', 'UserIncludes'))
+        # Create the commands buffer file
+        if not os.path.exists(command_buffer):
+            with open(command_buffer, 'w') as fopen:
+                fopen.write(' ')
+                
+        if os.path.exists(path_txt):
+            # Load the exe path from the file
+            with open(path_txt, 'r') as fopen:
+                exe_path = fopen.readline()
+            
+            # Write the exe_path into the bash buffer
+            with open(bash_buffer, 'w') as fopen:
+                fopen.write('"{}" "{}"'.format(exe_path, bash_buffer))
+        else:
+            # Fist-time installation: no path_txt file available
+            # Detect the AR version and installation path automatically
+            if os.path.exists("C:\\AsylumResearch\\v19"):
+                exe_path = "C:\\AsylumResearch\\v19\\RealTime\\Igor Pro Folder\\Igor.exe"
+            elif os.path.exists("C:\\AsylumResearch\\v18"):
+                exe_path = "C:\\AsylumResearch\\v18\\RealTime\\Igor Pro Folder\\Igor.exe"
+            elif os.path.exists("C:\\AsylumResearch\\v17"):
+                exe_path = "C:\\AsylumResearch\\v17\\RealTime\\Igor Pro Folder\\Igor.exe"
+            elif os.path.exists("C:\\AsylumResearch\\v16"):
+                exe_path = "C:\\AsylumResearch\\v16\\RealTime\\Igor Pro Folder\\Igor.exe"
+            elif os.path.exists("C:\\AsylumResearch\\v15"):
+                exe_path = "C:\\AsylumResearch\\v15\\RealTime\\Igor Pro Folder\\Igor.exe"
+            elif os.path.exists("C:\\AsylumResearch\\v14"):
+                exe_path = "C:\\AsylumResearch\\v14\\RealTime\\Igor Pro Folder\\Igor.exe"
+            elif os.path.exists("C:\\AsylumResearch\\v13"):
+                exe_path = "C:\\AsylumResearch\\v13\\RealTime\\Igor Pro Folder\\Igor.exe"
+            else:
+                print("No AR detected. Please modify path.txt manually to include the AR path.")
+        
+            with open(path_txt, 'w') as fopen:
+                fopen.write(exe_path)
+                
+            with open(bash_buffer, 'w') as fopen: 
+                fopen.write('"{}" "{}"'.format(exe_path, bash_buffer))
+
+            # Copy the user functions into the default include folder of AR
+            # shutil.copy(os.path.join(aespm.__path__, 'user functions', 'UserFunctions.ipf'), os.path.join(doc_path, 'AsylumResearch', 'UserIncludes'))
 
 	except PermissionError:
 		print('No writing permission to ~/Documents. Please create buffer folder and files manually.')

--- a/aespm/experiment.py
+++ b/aespm/experiment.py
@@ -24,7 +24,12 @@ if platform.system() == 'Windows':
     _command_buffer = os.path.join(_buffer_path, 'ToIgor.arcmd')
     _read_out_buffer = os.path.join(_buffer_path, 'readout.txt')
     _bash_buffer = os.path.join(_buffer_path, 'SendToIgor.bat')
-    _exe_path = r"C:\AsylumResearch\v19\RealTime\Igor Pro Folder\Igor.exe"
+    _path_txt = os.path.join(_buffer_path, 'path.txt')
+    
+    with open(_path_txt, 'r') as fopen:
+        _exe_path = fopen.readline()
+    
+    # _exe_path = r"C:\AsylumResearch\v19\RealTime\Igor Pro Folder\Igor.exe"
 else:
     _buffer_path = r"C:\Users\Asylum User\Documents\buffer"
     _command_buffer = r"C:\Users\Asylum User\Documents\buffer\ToIgor.arcmd"

--- a/aespm/utils.py
+++ b/aespm/utils.py
@@ -13,13 +13,10 @@ if platform.system() == 'Windows':
     read_out_buffer = os.path.join(buffer_path, 'readout.txt')
     bash_buffer = os.path.join(buffer_path, 'SendToIgor.bat')
     
-    if os.path.exists("C:\\AsylumResearch\\v19"):
-        exe_path = "C:\\AsylumResearch\\v19\\RealTime\\Igor Pro Folder\\Igor.exe"
-    elif os.path.exists("C:\\AsylumResearch\\v18"):
-        exe_path = "C:\\AsylumResearch\\v18\\RealTime\\Igor Pro Folder\\Igor.exe"
-    else:
-        exe_path = ""
-
+    path_txt = os.path.join(buffer_path, 'path.txt')
+    
+    with open(path_txt, 'r') as fopen:
+        exe_path = fopen.readline()
 
 class SharedInfo:
     '''


### PR DESCRIPTION
If your AR software is not installed in the default path, you can now manually modify the "path.txt" file in the "buffer" folder to configure it manually.